### PR TITLE
add debugMessages and functionCalls to the return object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+/.idea

--- a/lib/index.js
+++ b/lib/index.js
@@ -115,11 +115,13 @@ function firebaserulesTest(callback, _ref2) {
     var _results$testResults = _toArray(results.testResults),
         testCases = _results$testResults.slice(0);
 
-    var testResults = testCases.map(function (_ref3, idx) {
-      var state = _ref3.state;
+    var testResults = testCases.map(function (testCase, idx) {
+      var state = testCase.state;
       var _resourceObj$testSuit = resourceObj.testSuite.testCases[idx],
           expectation = _resourceObj$testSuit.expectation,
           request = _resourceObj$testSuit.request;
+      var debugMessages = testCase.debugMessages;
+      var functionCalls = testCase.functionCalls;
       var passed = state === 'SUCCESS';
       var result = passed ? 'PASSED' : 'FAILED';
       return {
@@ -127,9 +129,14 @@ function firebaserulesTest(callback, _ref2) {
         passed: passed,
         state: state,
         expectation: expectation,
+        debugMessages: debugMessages,
+        functionCalls: functionCalls,
         request: request,
         toString: function toString() {
-          return (passed ? 'PASSED' : 'FAILED') + ' ' + state + ' -> ' + expectation + ' ' + JSON.stringify(request);
+          var FgRed = "\x1b[31m";
+          var FgGreen = "\x1b[32m";
+          var escapeSequence = "\x1b[0m";
+          return (passed ? FgGreen + 'PASSED' + escapeSequence : FgRed + 'FAILED' + escapeSequence) + ' ' + state + ' -> ' + expectation + ' ' + JSON.stringify(request);
         }
       };
     });
@@ -140,11 +147,11 @@ function firebaserulesTest(callback, _ref2) {
   });
 }
 
-function testSecurityRules(callback, _ref4) {
-  var keyCredentialsPath = _ref4.keyCredentialsPath,
-      creds = _ref4.creds,
-      source = _ref4.source,
-      testSuite = _ref4.testSuite;
+function testSecurityRules(callback, _ref3) {
+  var keyCredentialsPath = _ref3.keyCredentialsPath,
+      creds = _ref3.creds,
+      source = _ref3.source,
+      testSuite = _ref3.testSuite;
   var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
   setVerboseMode(options.verbose);
   getAuthObj(runTests, {
@@ -171,10 +178,10 @@ function setVerboseMode() {
   verboseMode = value;
 }
 
-function logger(_ref5) {
-  var _ref5$type = _ref5.type,
-      type = _ref5$type === void 0 ? 'log' : _ref5$type,
-      msg = _ref5.msg;
+function logger(_ref4) {
+  var _ref4$type = _ref4.type,
+      type = _ref4$type === void 0 ? 'log' : _ref4$type,
+      msg = _ref4.msg;
 
   if (!verboseMode) {
     return;

--- a/src/index.js
+++ b/src/index.js
@@ -88,34 +88,56 @@ function firebaserulesTest(
 
     const { testResults: [...testCases] } = results;
 
-    const testResults = testCases.map(({ state }: { state: String }, idx) => {
-      const {
-        expectation,
-        request
-      }: {
-        expectation: String,
-        request: Object
-      } = resourceObj.testSuite.testCases[idx];
+    const testResults = testCases.map(
+      (
+        testCase: {
+          state: string,
+          debugMessages: Array,
+          functionCalls: Object
+        },
+        idx
+      ) => {
+        const state = testCase.state;
+        const {
+          expectation,
+          request
+        }: {
+          expectation: String,
+          request: Object
+        } = resourceObj.testSuite.testCases[idx];
 
-      const passed: Boolean = state === 'SUCCESS';
-      const result: String = passed ? 'PASSED' : 'FAILED';
+        const debugMessages = testCase.debugMessages;
+        const functionCalls = testCase.functionCalls;
+        const passed: Boolean = state === 'SUCCESS';
+        const result: String = passed ? 'PASSED' : 'FAILED';
 
-      return {
-        result,
-        passed,
-        state,
-        expectation,
-        request,
-        toString: () =>
-          (passed ? 'PASSED' : 'FAILED') +
-          ' ' +
-          state +
-          ' -> ' +
-          expectation +
-          ' ' +
-          JSON.stringify(request)
-      };
-    });
+        return {
+          result,
+          passed,
+          state,
+          expectation,
+          debugMessages,
+          functionCalls,
+          request,
+          toString: () => {
+            const FgRed = '\x1b[31m';
+            const FgGreen = '\x1b[32m';
+            const escapeSequence = '\x1b[0m';
+            return (
+              (passed
+                ? FgGreen + 'PASSED' + escapeSequence
+                : FgRed + 'FAILED' + escapeSequence) +
+              ' ' +
+              state +
+              ' -> ' +
+              expectation +
+              ' ' +
+              JSON.stringify(request)
+            );
+          }
+        };
+      }
+    );
 
     callback({ projectId, testResults });
   });


### PR DESCRIPTION
Thanks for the awesome package! I started experimenting today with it and as it is normally the case I ran into some issues. 
I was comparing the results from firestore-security-tests to the google API explorer and I found out that the api explorer is actually providing very valuable information for debugging. 
Debugmessages and functionscalls can help one to find out what the tests are doing wrong, so I fiddled around and added those to the object that is returned. 

My print results function looks like this:
```
function printResults(resultsObj) {

    var projectId = resultsObj.projectId,
        testResults = resultsObj.testResults,
        error = resultsObj.error,
        errMsg = resultsObj.errMsg;

    if (error) {
        return console.error('\n\ntestSecurityRules ERRORED:\n\n', errMsg, error);
    }

    console.log('\nTest results for '.concat(projectId, ':\n'));
    
    testResults.forEach(function (testResult) {
        console.log(testResult.toString())
        if(testResult.result === 'FAILED') {
            console.log(testResult.debugMessages)
            console.log(JSON.stringify(testResult.functionCalls))
        }
        return;
    });
}
```

ah, and to make it easier for me to spot failing and successful tests I'm adding some color to the PASSED and FAILED keywords in the toString method